### PR TITLE
Switch to relative imports for convenience

### DIFF
--- a/textwiz/__init__.py
+++ b/textwiz/__init__.py
@@ -32,3 +32,5 @@ def is_chat_model(model_name: str) -> bool:
 
     template = get_prompt_template(model_name)
     return template.default_mode == 'chat'
+
+# this is a test

--- a/textwiz/__init__.py
+++ b/textwiz/__init__.py
@@ -32,5 +32,3 @@ def is_chat_model(model_name: str) -> bool:
 
     template = get_prompt_template(model_name)
     return template.default_mode == 'chat'
-
-# this is a test

--- a/textwiz/__init__.py
+++ b/textwiz/__init__.py
@@ -8,6 +8,8 @@ from .code_parser import PythonParser
 from .streamer import TextContinuationStreamer
 # import it here so that the warnings are suppressed when doing `import textwiz`
 from . import warnings_suppressor
+# also import some of the submodules for convenience
+from . import loader, conversation_template, prompt_template
 
 
 __version__ = '0.0.7'

--- a/textwiz/__init__.py
+++ b/textwiz/__init__.py
@@ -1,13 +1,13 @@
 # Define easy entry points for most useful features
-from textwiz.generation import HFModel
-from textwiz.loader import load_model, load_tokenizer, load_model_and_tokenizer, estimate_model_gpu_footprint
-from textwiz.conversation_template import get_empty_conversation_template, get_conversation_from_yaml_template
-from textwiz.prompt_template import get_prompt_template
-from textwiz.stopping import StoppingType, create_stopping_criteria, post_process_sequences
-from textwiz.code_parser import PythonParser
-from textwiz.streamer import TextContinuationStreamer
-# import it here so that the warnings are suppressed when doing `import engine`
-from textwiz import warnings_suppressor
+from .generation import HFModel
+from .loader import load_model, load_tokenizer, load_model_and_tokenizer, estimate_model_gpu_footprint
+from .conversation_template import get_empty_conversation_template, get_conversation_from_yaml_template
+from .prompt_template import get_prompt_template
+from .stopping import StoppingType, create_stopping_criteria, post_process_sequences
+from .code_parser import PythonParser
+from .streamer import TextContinuationStreamer
+# import it here so that the warnings are suppressed when doing `import textwiz`
+from . import warnings_suppressor
 
 
 __version__ = '0.0.7'

--- a/textwiz/code_parser.py
+++ b/textwiz/code_parser.py
@@ -1,7 +1,7 @@
 import re
 from abc import ABC, abstractmethod
 
-from textwiz import utils
+from . import utils
 
 
 class CodeParser(ABC):

--- a/textwiz/conversation_template.py
+++ b/textwiz/conversation_template.py
@@ -4,8 +4,8 @@ This file contains the conversation templates for the models we use.
 import uuid
 import copy
 
-from textwiz import loader
-from textwiz import utils
+from . import loader
+from . import utils
 
 
 class GenericConversation(object):

--- a/textwiz/generation.py
+++ b/textwiz/generation.py
@@ -11,13 +11,13 @@ import scipy
 import numpy as np
 from transformers import StoppingCriteriaList, GenerationConfig
 
-from textwiz import loader
-from textwiz import stopping
-from textwiz import utils
-from textwiz.prompt_template import GenericPromptTemplate, get_prompt_template
-from textwiz.conversation_template import GenericConversation, get_empty_conversation_template, get_conversation_from_yaml_template
-from textwiz.code_parser import CodeParser
-from textwiz.constants import SENTENCEPIECE_CHARACTER
+from . import loader
+from . import stopping
+from . import utils
+from .prompt_template import GenericPromptTemplate, get_prompt_template
+from .conversation_template import GenericConversation, get_empty_conversation_template, get_conversation_from_yaml_template
+from .code_parser import CodeParser
+from .constants import SENTENCEPIECE_CHARACTER
 
 
 class HFModel(object):

--- a/textwiz/prompt_template.py
+++ b/textwiz/prompt_template.py
@@ -4,7 +4,7 @@ templates are especially not meant for conversations with the models, only for p
 memory of previous prompts.
 """
 
-from textwiz.loader import ALLOWED_MODELS
+from .loader import ALLOWED_MODELS
 
 PROMPT_MODES = ('default', 'generation', 'infill', 'chat')
 

--- a/textwiz/stopping.py
+++ b/textwiz/stopping.py
@@ -5,7 +5,7 @@ import torch
 import numpy as np
 from transformers import PreTrainedTokenizerBase, StoppingCriteria, StoppingCriteriaList
 
-from textwiz.code_parser import CodeParser
+from .code_parser import CodeParser
 
 # If we reach one of these patterns, it means that the model has finished generating the solution as a 
 # function and continues useless generation (basically stop words used in the Codex/HumanEval 

--- a/textwiz/streamer.py
+++ b/textwiz/streamer.py
@@ -1,6 +1,6 @@
 from transformers import TextIteratorStreamer, AutoTokenizer
 
-from textwiz.constants import SENTENCEPIECE_CHARACTER
+from .constants import SENTENCEPIECE_CHARACTER
 
 class TextContinuationStreamer(TextIteratorStreamer):
     """Same as `TextIteratorStreamer`, but add the first space that does not get added by default during 


### PR DESCRIPTION
Switch to relative import for convenience. Indeed, when cloning the repo (TextWiz folder) inside another project, absolute imports do not allow syntax such as `from TextWiz import textwiz` inside the other project files, because the package `textwiz` is then contained inside another folder (TextWiz folder). Relative imports solve this issue.